### PR TITLE
Add Travis ci & set CC to clang only when CC is undefined

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,17 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.5
+          packages:
+            - clang-3.5
+      env:
+        - MATRIX_EVAL="CC=clang-3.5"
+
+    # works on Precise and Trusty
+    - addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
             - llvm-toolchain-precise-3.6
           packages:
             - clang-3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,5 +78,9 @@ matrix:
 before_install:
   - eval "${MATRIX_EVAL}"
 
+before_script:
+  # Echo clang version for confirming
+  - clang --version
+
 script:
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -111,5 +111,8 @@ matrix:
 before_install:
   - eval "${MATRIX_EVAL}"
 
+before_script:
+  - ${CC} --version
+
 script:
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ os: linux
 matrix:
   include:
     # works on Precise and Trusty
-    - addons:
+    - name: "clang-3.4"
+      addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
@@ -15,7 +16,8 @@ matrix:
         - MATRIX_EVAL="CC=clang-3.4" # For clang 3.4
 
     # works on Precise and Trusty
-    - addons:
+    - name: "clang-3.5"
+      addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
@@ -26,7 +28,8 @@ matrix:
         - MATRIX_EVAL="CC=clang-3.5"
 
     # works on Precise and Trusty
-    - addons:
+    - name: "clang-3.6"
+      addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
@@ -37,7 +40,8 @@ matrix:
         - MATRIX_EVAL="CC=clang-3.6"
 
     # works on Precise and Trusty
-    - addons:
+    - name: "clang-3.7"
+      addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
@@ -48,7 +52,8 @@ matrix:
         - MATRIX_EVAL="CC=clang-3.7"
 
     # works on Precise and Trusty
-    - addons:
+    - name: "clang-3.8"
+      addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
@@ -59,7 +64,8 @@ matrix:
         - MATRIX_EVAL="CC=clang-3.8"
 
     # works on Trusty
-    - addons:
+    - name: "clang-3.9"
+      addons:
         apt:
           sources:
             - llvm-toolchain-trusty-3.9
@@ -69,7 +75,8 @@ matrix:
         - MATRIX_EVAL="CC=clang-3.9"
 
     # works on Trusty
-    - addons:
+    - name: "clang-4.0"
+      addons:
         apt:
           sources:
             - llvm-toolchain-trusty-4.0
@@ -79,7 +86,8 @@ matrix:
         - MATRIX_EVAL="CC=clang-4.0"
 
     # works on Trusty
-    - addons:
+    - name: "clang-5.0"
+      addons:
         apt:
           sources:
             - llvm-toolchain-trusty-5.0
@@ -89,7 +97,8 @@ matrix:
         - MATRIX_EVAL="CC=clang-5.0"
 
     # works on Trusty
-    - addons:
+    - name: "clang-6.0"
+      addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ matrix:
         - MATRIX_EVAL="CC=clang-6.0"
 
 before_install:
-    - eval "${MATRIX_EVAL}"
+  - eval "${MATRIX_EVAL}"
 
 script:
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: required
 language: c
 os: linux
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,7 @@ matrix:
     - addons:
         apt:
           sources:
+            - ubuntu-toolchain-r-test
             - llvm-toolchain-trusty-6.0
           packages:
             - clang-6.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,16 @@ matrix:
       env:
         - MATRIX_EVAL="CC=clang-5.0"
 
+    # works on Trusty
+    - addons:
+        apt:
+          sources:
+            - llvm-toolchain-trusty-6.0
+          packages:
+            - clang-6.0
+      env:
+        - MATRIX_EVAL="CC=clang-6.0"
+
 before_install:
     - eval "${MATRIX_EVAL}"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,18 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
+            - sourceline: "deb http://apt.llvm.org/precise/ llvm-toolchain-precise-3.4 main"
+            - key_url: "http://apt.llvm.org/llvm-snapshot.gpg.key"
+          packages:
+            - clang-3.4
+      env:
+        - MATRIX_EVAL="CC=clang-3.4" # For clang 3.4
+
+    # works on Precise and Trusty
+    - addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
             - llvm-toolchain-precise-3.5
           packages:
             - clang-3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
           packages:
             - clang-3.8
       env:
-        - MATRIX_EVAL="CC=clang-3.8
+        - MATRIX_EVAL="CC=clang-3.8"
 
     # works on Trusty
     - addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,9 +78,5 @@ matrix:
 before_install:
   - eval "${MATRIX_EVAL}"
 
-before_script:
-  # Echo clang version for confirming
-  - clang --version
-
 script:
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,73 @@
+sudo: required
+language: c
+os: linux
+matrix:
+  include:
+    # works on Precise and Trusty
+    - addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.6
+          packages:
+            - clang-3.6
+      env:
+        - MATRIX_EVAL="CC=clang-3.6"
+
+    # works on Precise and Trusty
+    - addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.7
+          packages:
+            - clang-3.7
+      env:
+        - MATRIX_EVAL="CC=clang-3.7"
+
+    # works on Precise and Trusty
+    - addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.8
+          packages:
+            - clang-3.8
+      env:
+        - MATRIX_EVAL="CC=clang-3.8
+
+    # works on Trusty
+    - addons:
+        apt:
+          sources:
+            - llvm-toolchain-trusty-3.9
+          packages:
+            - clang-3.9
+      env:
+        - MATRIX_EVAL="CC=clang-3.9"
+
+    # works on Trusty
+    - addons:
+        apt:
+          sources:
+            - llvm-toolchain-trusty-4.0
+          packages:
+            - clang-4.0
+      env:
+        - MATRIX_EVAL="CC=clang-4.0"
+
+    # works on Trusty
+    - addons:
+        apt:
+          sources:
+            - llvm-toolchain-trusty-5.0
+          packages:
+            - clang-5.0
+      env:
+        - MATRIX_EVAL="CC=clang-5.0"
+
+before_install:
+    - eval "${MATRIX_EVAL}"
+
+script:
+  - make

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CC=clang
+CC?=clang
 AR=ar
 CFLAGS=-c -Iinclude
 LIB=lib/libcs1010.a

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Build Status](https://travis-ci.org/nus-cs1010-1819-s1/libcs1010.svg?branch=master)](https://travis-ci.org/nus-cs1010-1819-s1/libcs1010)
 # The CS1010 I/O Library
 
 To help students get started with C programming without worrying too much about the details and pitfalls of using `printf` and `scanf`, CS1010 provides a simple-to-use library to read and write integers, floating point numbers, and strings.


### PR DESCRIPTION
This PR brings Travis CI to libcs1010. For every commit, it will try to build libcs1010 and report whether the build was successful. Travis CI will try to build using all the supporting compilers as stated in https://github.com/nus-cs1010/1819-s1/blob/7fc89b05644c2d9fdb9007d60da33e02b87f9c03/docs/environments.md (clang 3.4 or later). If I missed any version, please commit directly or comment to this PR then I will do it. 

This also makes the `Makefile` set `CC` to `clang` only when `CC` is undefined. Since under some environment, `clang` is available in other names (e.g. `clang-3.7`) instead of `clang`. Doing this hard-coding will break in such situation. However, for now, if `CC` variable is specified to a compiler that is unsupported, it won't build even `clang` command is available. But, I guess this is expected.