### PR TITLE
chore(Makefile): force using `clang` as the compiler & ci(travis): fix `clang` not found problems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: required
 language: c
 os: linux
 matrix:
@@ -110,9 +111,10 @@ matrix:
 
 before_install:
   - eval "${MATRIX_EVAL}"
+  - sudo ln -s "`which ${CC}`" /usr/bin/clang
 
 before_script:
-  - ${CC} --version
+  - clang --version
 
 script:
   - make

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CC?=clang
+CC=clang
 AR=ar
 CFLAGS=-c -Iinclude
 LIB=lib/libcs1010.a


### PR DESCRIPTION
Asked by @weitsang , `Makefile` back to force using `clang` command as the compiler. The corresponding fix for Travis is also done.

Note that: Some packages providing clang might not provide the command `clang`. They might be in the form of `clang-VERSION` (e.g. `clang-3.8`). And this PR will break the compilation in such environment.